### PR TITLE
sqlite: fix empty string handling

### DIFF
--- a/cgosqlite/cgosqlite.go
+++ b/cgosqlite/cgosqlite.go
@@ -259,10 +259,10 @@ func (stmt *Stmt) BindNull(col int) error {
 // BindText64 is sqlite3_bind_text64.
 // https://sqlite.org/c3ref/bind_blob.html
 func (stmt *Stmt) BindText64(col int, val string) error {
-	v := emptyCStr
-	if len(val) > 0 {
-		v = C.CString(val) // freed by sqlite
+	if len(val) == 0 {
+		return errCode(C.bind_text64_empty(stmt.stmt, C.int(col)))
 	}
+	v := C.CString(val) // freed by sqlite
 	return errCode(C.bind_text64(stmt.stmt, C.int(col), v, C.sqlite3_uint64(len(val))))
 }
 

--- a/cgosqlite/cgosqlite.h
+++ b/cgosqlite/cgosqlite.h
@@ -4,6 +4,10 @@ static int bind_text64(sqlite3_stmt* stmt, int col, const char* str, sqlite3_uin
 	return sqlite3_bind_text64(stmt, col, str, len, free, SQLITE_UTF8);
 }
 
+static int bind_text64_empty(sqlite3_stmt* stmt, int col) {
+	return sqlite3_bind_text64(stmt, col, "", 0, SQLITE_STATIC, SQLITE_UTF8);
+}
+
 static int bind_blob64(sqlite3_stmt* stmt, int col, char* str, sqlite3_uint64 n) {
 	return sqlite3_bind_blob64(stmt, col, str, n, SQLITE_TRANSIENT);
 }

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -274,6 +274,20 @@ func TestShortTimes(t *testing.T) {
 	}
 }
 
+func TestEmptyString(t *testing.T) {
+	db := openTestDB(t)
+	exec(t, db, "CREATE TABLE t (c)")
+	exec(t, db, "INSERT INTO t VALUES (?)", "")
+	exec(t, db, "INSERT INTO t VALUES (?)", "")
+	var count int
+	if err := db.QueryRowContext(context.Background(), "SELECT count(*) FROM t").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Fatalf("count=%d, want 2", count)
+	}
+}
+
 // TODO(crawshaw): test TextMarshaler
 // TODO(crawshaw): test named types
 // TODO(crawshaw): check coverage


### PR DESCRIPTION
Avoids `free(): double free detected in tcache 2`

Signed-off-by: David Crawshaw <crawshaw@tailscale.com>