### PR TITLE
sqlite: speed up persistent queries

### DIFF
--- a/cgosqlite/cgosqlite.go
+++ b/cgosqlite/cgosqlite.go
@@ -148,6 +148,10 @@ func (stmt *Stmt) ClearBindings() error {
 	return errCode(C.sqlite3_clear_bindings(stmt.stmt))
 }
 
+func (stmt *Stmt) ResetAndClear() error {
+	return errCode(C.reset_and_clear(stmt.stmt))
+}
+
 func (stmt *Stmt) ColumnDatabaseName(col int) string {
 	return C.GoString((*C.char)(unsafe.Pointer(C.sqlite3_column_database_name(stmt.stmt, C.int(col)))))
 }

--- a/cgosqlite/cgosqlite.h
+++ b/cgosqlite/cgosqlite.h
@@ -36,3 +36,13 @@ static int step_result(sqlite3_stmt* stmt, sqlite3_int64* rowid, sqlite3_int64* 
 	*changes = sqlite3_changes(db);
 	return ret;
 }
+
+// reset_and_clear combines two cgo calls to save overhead.
+static int reset_and_clear(sqlite3_stmt* stmt) {
+	int ret = sqlite3_reset(stmt);
+	int ret2 = sqlite3_clear_bindings(stmt);
+	if (ret != SQLITE_OK) {
+		return ret;
+	}
+	return ret2;
+}

--- a/sqlite.go
+++ b/sqlite.go
@@ -257,6 +257,7 @@ type stmt struct {
 	// filled on first step only if persist==true
 	colTypes     []sqliteh.ColumnType
 	colDeclTypes []string
+	colNames     []string
 }
 
 func (s *stmt) reserr(loc string, err error) error { return reserr(s.db, loc, s.query, err) }
@@ -454,9 +455,16 @@ func (r *rows) Columns() []string {
 		panic("Columns called after Rows was closed")
 	}
 	if r.colNames == nil {
-		r.colNames = make([]string, r.stmt.stmt.ColumnCount())
-		for i := range r.colNames {
-			r.colNames[i] = r.stmt.stmt.ColumnName(i)
+		if r.stmt.colNames != nil {
+			r.colNames = r.stmt.colNames
+		} else {
+			r.colNames = make([]string, r.stmt.stmt.ColumnCount())
+			for i := range r.colNames {
+				r.colNames[i] = r.stmt.stmt.ColumnName(i)
+			}
+			if r.stmt.persist {
+				r.stmt.colNames = r.colNames
+			}
 		}
 	}
 	return append([]string{}, r.colNames...)

--- a/sqliteh/sqliteh.go
+++ b/sqliteh/sqliteh.go
@@ -58,6 +58,8 @@ type Stmt interface {
 	// Reset is sqlite3_reset.
 	// https://www.sqlite.org/c3ref/reset.html
 	Reset() error
+	// ResetAndClear is sqlite3_reset + sqlite3_clear_bindings.
+	ResetAndClear() error
 	// Finalize is sqlite3_finalize.
 	// https://sqlite.org/c3ref/finalize.html
 	Finalize() error


### PR DESCRIPTION
Best read commit-by-commit. Each includes relative benchmark performance to the commit before. Overall results of this PR:

```
name        old time/op  new time/op  delta
Persist-24  2.68µs ± 1%  2.03µs ± 1%  -24.00%  (p=0.000 n=20+20)
```