### PR TITLE
sqlite, etc: move reset into step_result

### DIFF
--- a/cgosqlite/cgosqlite.h
+++ b/cgosqlite/cgosqlite.h
@@ -28,12 +28,14 @@ static int bind_parameter_index(sqlite3_stmt* stmt, _GoString_ s) {
 	return sqlite3_bind_parameter_index(stmt, zName);
 }
 
-// step_result combines three cgo calls to save overhead.
+// step_result combines several cgo calls to save overhead.
 static int step_result(sqlite3_stmt* stmt, sqlite3_int64* rowid, sqlite3_int64* changes) {
 	int ret = sqlite3_step(stmt);
 	sqlite3* db = sqlite3_db_handle(stmt);
 	*rowid = sqlite3_last_insert_rowid(db);
 	*changes = sqlite3_changes(db);
+	sqlite3_reset(stmt);
+	sqlite3_clear_bindings(stmt);
 	return ret;
 }
 

--- a/sqlite.go
+++ b/sqlite.go
@@ -288,15 +288,15 @@ func (s *stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (drive
 	if err := s.resetAndClear(); err != nil {
 		return nil, s.reserr("Stmt.Query(Reset)", err)
 	}
-	defer s.resetAndClear() // returns same error as StepResult
 	if err := s.bindAll(args); err != nil {
 		return nil, err
 	}
 	row, lastInsertRowID, changes, err := s.stmt.StepResult()
-	_ = row // TODO: return error if exec on query which returns rows?
+	s.bound = false // StepResult resets the query
 	if err != nil {
 		return nil, err
 	}
+	_ = row // TODO: return error if exec on query which returns rows?
 	return stmtResult{lastInsertID: lastInsertRowID, rowsAffected: changes}, nil
 }
 

--- a/sqliteh/sqliteh.go
+++ b/sqliteh/sqliteh.go
@@ -73,10 +73,14 @@ type Stmt interface {
 	// 	For any error, Step retursn (false, err).
 	// https://www.sqlite.org/c3ref/step.html
 	Step() (row bool, err error)
-	// StepResult is sqlite3_step + sqlite3_last_insert_rowid + sqlite3_changes.
-	// 	For SQLITE_ROW, Step returns (true, nil).
-	// 	For SQLITE_DONE, Step returns (false, nil).
-	// 	For any error, Step retursn (false, err).
+	// StepResult executes a one-row query and resets the statment:
+	//	sqlite3_step
+	//	sqlite3_last_insert_rowid + sqlite3_changes
+	//	sqlite3_reset + sqlite3_clear_bindings
+	// Results:
+	// 	For SQLITE_ROW, Step returns row=true err=nil
+	// 	For SQLITE_DONE, Step returns row=false err=nil
+	// 	For any error, Step returns row=false err.
 	// https://www.sqlite.org/c3ref/step.html
 	StepResult() (row bool, lastInsertRowID, changes int64, err error)
 	// BindDouble is sqlite3_bind_double.


### PR DESCRIPTION
Grinding away at cgo overhead.

	name          old time/op  new time/op  delta
	EmptyExec-24   439ns ± 0%   386ns ± 0%  -12.00%  (p=0.000 n=19+17)

Signed-off-by: David Crawshaw <crawshaw@tailscale.com>