### PR TITLE
sqlite, etc: add tracing API

### DIFF
--- a/sqliteh/sqliteh.go
+++ b/sqliteh/sqliteh.go
@@ -59,11 +59,14 @@ type Stmt interface {
 	// ExpandedSQL is sqlite3_expanded_sql.
 	// https://www.sqlite.org/c3ref/expanded_sql.html
 	ExpandedSQL() string
+	// StartTimer starts recording elapsed duration.
+	StartTimer()
 	// Reset is sqlite3_reset.
 	// https://www.sqlite.org/c3ref/reset.html
 	Reset() error
 	// ResetAndClear is sqlite3_reset + sqlite3_clear_bindings.
-	ResetAndClear() error
+	// It reports the duration elapsed since the call to StartTimer.
+	ResetAndClear() (time.Duration, error)
 	// Finalize is sqlite3_finalize.
 	// https://sqlite.org/c3ref/finalize.html
 	Finalize() error
@@ -86,7 +89,7 @@ type Stmt interface {
 	// 	For SQLITE_DONE, Step returns row=false err=nil
 	// 	For any error, Step returns row=false err.
 	// https://www.sqlite.org/c3ref/step.html
-	StepResult() (row bool, lastInsertRowID, changes int64, err error)
+	StepResult() (row bool, lastInsertRowID, changes int64, d time.Duration, err error)
 	// BindDouble is sqlite3_bind_double.
 	// https://sqlite.org/c3ref/bind_blob.html
 	BindDouble(col int, val float64) error


### PR DESCRIPTION
Our expected use of this will be as an "event" API, not a tracing API.
But for future users, I included a traceID, that could be used to
retrofit one of those large trace/span systems onto the driver if you
were so inclined.

Minimal benchmark impact:

	Persist-24    1.93µs ± 1%  1.92µs ± 1%  -0.51%  (p=0.000 n=19+18)
	EmptyExec-24   386ns ± 0%   401ns ± 1%  +3.85%  (p=0.000 n=17+20)

Signed-off-by: David Crawshaw <crawshaw@tailscale.com>