### PR TITLE
sqlite: really close

### DIFF
--- a/sqlite.go
+++ b/sqlite.go
@@ -152,6 +152,10 @@ type conn struct {
 func (c *conn) Prepare(query string) (driver.Stmt, error) { panic("deprecated, unused") }
 func (c *conn) Begin() (driver.Tx, error)                 { panic("deprecated, unused") }
 func (c *conn) Close() error {
+	for q, s := range c.stmts {
+		s.stmt.Finalize()
+		delete(c.stmts, q)
+	}
 	return reserr(c.db, "Conn.Close", "", c.db.Close())
 }
 func (c *conn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {


### PR DESCRIPTION
sqlite3_close doesn't close the DB unless all the prepared statements
are finalized. Callers of the package can get this right for
non-persistent queries, but for the persistent ones we need to clear our
internal cache.

This doesn't have a test because the sql.Conn.Close method eats errors
from the driver. Easily manually testable by taking SQL-based tests and
running them with -count=1000, as you run out of fds.

Signed-off-by: David Crawshaw <crawshaw@tailscale.com>