### PR TITLE
sqlite: delay BEGIN on transactions

### DIFF
--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -666,6 +666,28 @@ func BenchmarkEmptyExec(b *testing.B) {
 	}
 }
 
+func BenchmarkBeginTxNoop(b *testing.B) {
+	ctx := context.Background()
+	db := openTestDB(b)
+	for i := 0; i < b.N; i++ {
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err := tx.Rollback(); err != nil {
+			b.Fatal(err)
+		}
+
+		tx, err = db.BeginTx(ctx, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err := tx.Commit(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 // TODO(crawshaw): test TextMarshaler
 // TODO(crawshaw): test named types
 // TODO(crawshaw): check coverage


### PR DESCRIPTION
Don't call BEGIN until a transaction actually gets used, so that if a caller calls BeginTx then Rollback, there's no cgo+db accounting.

```
	name            old time/op  new time/op  delta
	BeginTxNoop-10  1.84µs ± 0%  1.10µs ± 1%  -39.93%  (p=0.000 n=9+10)
```