### PR TITLE
sqlite, cgosqlite: fix TestTrace on macOS

### DIFF
--- a/cgosqlite/cgosqlite.go
+++ b/cgosqlite/cgosqlite.go
@@ -31,6 +31,14 @@ package cgosqlite
 // #cgo linux LDFLAGS: -ldl -lm -lrt
 // #cgo linux CFLAGS: -std=c99
 //
+// // TODO(crawshaw): for some reason, I cannot get CLOCK_MONOTONIC
+// // defined properly here by cgo. My C compiler seems otherwise
+// // fine, I can compile a small C program on linux referring to
+// // CLOCK_MONOTONIC.
+// //
+// // For now, use the value directly. It's a fixed value on linux.
+// #cgo linux CFLAGS: -DCLOCK_MONOTONIC=1
+//
 // #include <stdint.h>
 // #include <stdlib.h>
 // #include <string.h>

--- a/cgosqlite/cgosqlite.h
+++ b/cgosqlite/cgosqlite.h
@@ -29,14 +29,7 @@ static int bind_parameter_index(sqlite3_stmt* stmt, _GoString_ s) {
 }
 
 static void monotonic_clock_gettime(struct timespec* t) {
-	// TODO(crawshaw): for some reason, I cannot get CLOCK_MONOTONIC
-	// defined properly here by cgo. My C compiler seems otherwise
-	// fine, I can compile a small C program on linux referring to
-	// CLOCK_MONOTONIC.
-	// 
-	// For now, use the value directly.
-	// It is defined in POSIX so it won't change any time soon.
-	clock_gettime(1, t); // CLOCK_MONOTONIC
+	clock_gettime(CLOCK_MONOTONIC, t);
 }
 
 static int64_t ns_since(const struct timespec t1)

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -514,7 +514,11 @@ func TestTrace(t *testing.T) {
 			t.Errorf("trace: err=%v, want %v", ev.err, errSubstr)
 		}
 		if ev.duration <= 0 || ev.duration > 10*time.Minute {
-			t.Errorf("trace: improbable duration: %v", ev.duration)
+			// The macOS clock appears to low resolution and so
+			// it's common to get a duration of exactly 0s.
+			if runtime.GOOS == "darwin" && ev.duration != 0 {
+				t.Errorf("trace: improbable duration: %v", ev.duration)
+			}
 		}
 	}
 	db := openTestDBTrace(t, fn)


### PR DESCRIPTION
	--- FAIL: TestTrace (0.00s)
	    sqlite_test.go:522: trace: improbable duration: -513288h42m26.15796988s
	    sqlite_test.go:523: trace: improbable duration: -513288h42m26.15796988s
	    sqlite_test.go:558: trace: improbable duration: 0s

Two problems:

1. It turns out CLOCK_MONOTONIC is 6 on macOS. Oops.
   My comment claims it was defined as 1 in the POSIX spec,
   but now I can't find it. So I can only say it's 1 on linux.

2. clock_gettime does not seem to have much resolution on
   macOS, so I see some zeros. Ignore them.