### PR TITLE
sqlite, sqliteh: move Tracer interface

### DIFF
--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -65,7 +65,7 @@ func openTestDB(t testing.TB) *sql.DB {
 	return db
 }
 
-func openTestDBTrace(t testing.TB, tracer Tracer) *sql.DB {
+func openTestDBTrace(t testing.TB, tracer sqliteh.Tracer) *sql.DB {
 	t.Helper()
 	db := sql.OpenDB(Connector("file:"+t.TempDir()+"/test.db", nil, tracer))
 	configDB(t, db)
@@ -491,13 +491,13 @@ type queryTracer struct {
 	evCh chan queryTraceEvent
 }
 
-func (t *queryTracer) Query(prepCtx context.Context, id TraceConnID, query string, duration time.Duration, err error) {
+func (t *queryTracer) Query(prepCtx context.Context, id sqliteh.TraceConnID, query string, duration time.Duration, err error) {
 	t.evCh <- queryTraceEvent{prepCtx, query, duration, err}
 }
-func (t *queryTracer) BeginTx(_ context.Context, _ TraceConnID, _ bool, _ error) {}
-func (t *queryTracer) Commit(_ TraceConnID, _ error) {
+func (t *queryTracer) BeginTx(_ context.Context, _ sqliteh.TraceConnID, _ bool, _ error) {}
+func (t *queryTracer) Commit(_ sqliteh.TraceConnID, _ error) {
 }
-func (t *queryTracer) Rollback(_ TraceConnID, _ error) {
+func (t *queryTracer) Rollback(_ sqliteh.TraceConnID, _ error) {
 }
 
 func TestTraceQuery(t *testing.T) {

--- a/sqlstats/sqlstats.go
+++ b/sqlstats/sqlstats.go
@@ -12,7 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/tailscale/sqlite"
+	"github.com/tailscale/sqlite/sqliteh"
 )
 
 // Tracer implements sqlite.Tracer and collects query stats.
@@ -80,7 +80,7 @@ func (t *Tracer) collect() (rows []queryStats) {
 	return rows
 }
 
-func (t *Tracer) Query(prepCtx context.Context, id sqlite.TraceConnID, query string, duration time.Duration, err error) {
+func (t *Tracer) Query(prepCtx context.Context, id sqliteh.TraceConnID, query string, duration time.Duration, err error) {
 	stats := t.queryStats(query)
 
 	atomic.AddInt64(&stats.count, 1)
@@ -90,9 +90,10 @@ func (t *Tracer) Query(prepCtx context.Context, id sqlite.TraceConnID, query str
 	}
 }
 
-func (t *Tracer) BeginTx(beginCtx context.Context, id sqlite.TraceConnID, readOnly bool, err error) {}
-func (t *Tracer) Commit(id sqlite.TraceConnID, err error)                                           {}
-func (t *Tracer) Rollback(id sqlite.TraceConnID, err error)                                         {}
+func (t *Tracer) BeginTx(beginCtx context.Context, id sqliteh.TraceConnID, readOnly bool, err error) {
+}
+func (t *Tracer) Commit(id sqliteh.TraceConnID, err error)   {}
+func (t *Tracer) Rollback(id sqliteh.TraceConnID, err error) {}
 
 func (t *Tracer) Handle(w http.ResponseWriter, r *http.Request) {
 	getArgs, _ := url.ParseQuery(r.URL.RawQuery)


### PR DESCRIPTION
So we can use the Tracer without the driver.