### PR TITLE
sqlstats, sqliteh: connection stats, and plumb why

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/tailscale/sqlite
 
-go 1.16
+go 1.18

--- a/sqlite.go
+++ b/sqlite.go
@@ -269,7 +269,7 @@ func (c *conn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, e
 	c.readOnly = opts.ReadOnly
 	c.txState = txStateInit
 	if c.tracer != nil {
-		c.tracer.BeginTx(ctx, c.id, c.readOnly, nil)
+		c.tracer.BeginTx(ctx, c.id, "", c.readOnly, nil)
 	}
 	if err := c.txInit(ctx); err != nil {
 		return nil, err

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -494,7 +494,7 @@ type queryTracer struct {
 func (t *queryTracer) Query(prepCtx context.Context, id sqliteh.TraceConnID, query string, duration time.Duration, err error) {
 	t.evCh <- queryTraceEvent{prepCtx, query, duration, err}
 }
-func (t *queryTracer) BeginTx(_ context.Context, _ sqliteh.TraceConnID, _ bool, _ error) {}
+func (t *queryTracer) BeginTx(_ context.Context, _ sqliteh.TraceConnID, _ string, _ bool, _ error) {}
 func (t *queryTracer) Commit(_ sqliteh.TraceConnID, _ error) {
 }
 func (t *queryTracer) Rollback(_ sqliteh.TraceConnID, _ error) {

--- a/sqliteh/sqliteh.go
+++ b/sqliteh/sqliteh.go
@@ -882,7 +882,7 @@ type Tracer interface {
 	Query(prepCtx context.Context, id TraceConnID, query string, duration time.Duration, err error)
 
 	// BeginTx is called by the driver to report the beginning of Tx.
-	BeginTx(beginCtx context.Context, id TraceConnID, readOnly bool, err error)
+	BeginTx(beginCtx context.Context, id TraceConnID, why string, readOnly bool, err error)
 
 	// Commit is called by the driver to report the end of a Tx.
 	Commit(id TraceConnID, err error)

--- a/sqlstats/sqlstats.go
+++ b/sqlstats/sqlstats.go
@@ -4,6 +4,7 @@ package sqlstats
 import (
 	"context"
 	"fmt"
+	"html"
 	"net/http"
 	"net/url"
 	"sort"
@@ -20,6 +21,8 @@ import (
 // To use, pass the tracer object to sqlite.Connector, then start a debug
 // web server with http.HandlerFunc(sqlTracer.Handle).
 type Tracer struct {
+	curTxs sync.Map // TraceConnID -> *connStats
+
 	// Once a query has been seen once, only the read lock
 	// is required to update stats.
 	//
@@ -28,6 +31,21 @@ type Tracer struct {
 	// here.
 	mu      sync.RWMutex
 	queries map[string]*queryStats // query -> stats
+}
+
+type connStats struct {
+	mu       sync.Mutex
+	why      string
+	at       time.Time
+	readOnly bool
+}
+
+func (s *connStats) clear() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.why = ""
+	s.at = time.Time{}
+	s.readOnly = false
 }
 
 type queryStats struct {
@@ -90,10 +108,78 @@ func (t *Tracer) Query(prepCtx context.Context, id sqliteh.TraceConnID, query st
 	}
 }
 
-func (t *Tracer) BeginTx(beginCtx context.Context, id sqliteh.TraceConnID, readOnly bool, err error) {
+func (t *Tracer) connStats(id sqliteh.TraceConnID) *connStats {
+	var s *connStats
+	v, ok := t.curTxs.Load(id)
+	if ok {
+		s = v.(*connStats)
+	} else {
+		s = &connStats{}
+		t.curTxs.Store(id, s)
+	}
+	return s
 }
-func (t *Tracer) Commit(id sqliteh.TraceConnID, err error)   {}
-func (t *Tracer) Rollback(id sqliteh.TraceConnID, err error) {}
+
+func (t *Tracer) BeginTx(beginCtx context.Context, id sqliteh.TraceConnID, why string, readOnly bool, err error) {
+	s := t.connStats(id)
+
+	s.mu.Lock()
+	s.why = why
+	s.at = time.Now()
+	s.readOnly = readOnly
+	s.mu.Unlock()
+}
+
+func (t *Tracer) Commit(id sqliteh.TraceConnID, err error) {
+	s := t.connStats(id)
+	s.clear()
+}
+
+func (t *Tracer) Rollback(id sqliteh.TraceConnID, err error) {
+	s := t.connStats(id)
+	s.clear()
+}
+
+func (t *Tracer) HandleConns(w http.ResponseWriter, r *http.Request) {
+	type txSummary struct {
+		name     string
+		start    time.Time
+		readOnly bool
+	}
+	var summary []txSummary
+
+	t.curTxs.Range(func(k, v any) bool {
+		s := v.(*connStats)
+
+		s.mu.Lock()
+		summary = append(summary, txSummary{
+			name:     s.why,
+			start:    s.at,
+			readOnly: s.readOnly,
+		})
+		s.mu.Unlock()
+
+		return true
+	})
+
+	sort.Slice(summary, func(i, j int) bool { return summary[i].start.Before(summary[j].start) })
+
+	now := time.Now()
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(200)
+	fmt.Fprintf(w, "<!DOCTYPE html><html><title>sqlite conns</title><body>\n")
+	fmt.Fprintf(w, "<p>outstanding sqlite transactions: %d</p>\n", len(summary))
+	fmt.Fprintf(w, "<pre>\n")
+	for _, s := range summary {
+		rw := ""
+		if !s.readOnly {
+			rw = " read-write"
+		}
+		fmt.Fprintf(w, "\n\t%s (%v)%s", html.EscapeString(s.name), now.Sub(s.start).Round(time.Millisecond), rw)
+	}
+	fmt.Fprintf(w, "</pre></body></html>\n")
+}
 
 func (t *Tracer) Handle(w http.ResponseWriter, r *http.Request) {
 	getArgs, _ := url.ParseQuery(r.URL.RawQuery)


### PR DESCRIPTION
This uses the sqlstats tracer to track current active transactions, and
how long they have been running for.

The database/sql driver does not have a Tx reason to plumb into 'why',
but the new sqlitepool does.