### PR TITLE
sqlite: support sql.RawBytes (return []byte in driver.Value)

### DIFF
--- a/cgosqlite/cgosqlite.go
+++ b/cgosqlite/cgosqlite.go
@@ -378,7 +378,7 @@ func (stmt *Stmt) ColumnText(col int) string {
 }
 
 func (stmt *Stmt) ColumnBlob(col int) []byte {
-	res := C.sqlite3_column_blob(stmt.stmt.ptr(), C.int(col))
+	res := C.ts_sqlite3_column_blob(stmt.stmt.int(), C.int(col))
 	if res == nil {
 		return nil
 	}

--- a/cgosqlite/cgosqlite.h
+++ b/cgosqlite/cgosqlite.h
@@ -106,6 +106,10 @@ static const unsigned char *ts_sqlite3_column_text(handle_sqlite3_stmt stmt, int
 	return sqlite3_column_text((sqlite3_stmt*)(stmt), iCol);
 }
 
+static const unsigned char *ts_sqlite3_column_blob(handle_sqlite3_stmt stmt, int iCol) {
+	return sqlite3_column_blob((sqlite3_stmt*)(stmt), iCol);
+}
+
 static int ts_sqlite3_column_type(handle_sqlite3_stmt stmt, int iCol) {
 	return sqlite3_column_type((sqlite3_stmt*)(stmt), iCol);
 }

--- a/sqlite.go
+++ b/sqlite.go
@@ -719,9 +719,7 @@ func (r *rows) Next(dest []driver.Value) error {
 			}
 		case sqliteh.SQLITE_FLOAT:
 			dest[i] = r.stmt.stmt.ColumnDouble(i)
-		case sqliteh.SQLITE_TEXT:
-			dest[i] = r.stmt.stmt.ColumnText(i)
-		case sqliteh.SQLITE_BLOB:
+		case sqliteh.SQLITE_BLOB, sqliteh.SQLITE_TEXT:
 			dest[i] = r.stmt.stmt.ColumnBlob(i)
 		case sqliteh.SQLITE_NULL:
 			dest[i] = nil


### PR DESCRIPTION
The https://pkg.go.dev/database/sql/driver#Value type can be either string or []byte, but []byte permits database/sql scanning into *sql.RawBytes without allocating. We were previously returning strings all the time if that's what SQLite thought it was. (But Go doesn't distinguish between "TEXT" and "BLOB" ... either are just some bytes)

This effectively moves any allocation (from []byte to string or []byte to clone of []byte) later, letting it be managed by database/sql.

                             │   before    │               after                │
                             │   sec/op    │   sec/op     vs base               │
    QueryRows100MixedTypes-8   37.61µ ± 1%   36.60µ ± 0%  -2.67% (p=0.000 n=10)

                             │    before    │                after                 │
                             │     B/op     │     B/op      vs base                │
    QueryRows100MixedTypes-8   4.281Ki ± 0%   2.719Ki ± 0%  -36.50% (p=0.000 n=10)

                             │   before   │               after                │
                             │ allocs/op  │ allocs/op   vs base                │
    QueryRows100MixedTypes-8   207.0 ± 0%   107.0 ± 0%  -48.31% (p=0.000 n=10)