### PR TITLE
cgosqlite: get column types during Step

### DIFF
--- a/cgosqlite/cgosqlite.go
+++ b/cgosqlite/cgosqlite.go
@@ -272,8 +272,12 @@ func (stmt *Stmt) ColumnTableName(col int) string {
 	return C.GoString((*C.char)(unsafe.Pointer(C.sqlite3_column_table_name(stmt.stmt.ptr(), C.int(col)))))
 }
 
-func (stmt *Stmt) Step() (row bool, err error) {
-	res := C.ts_sqlite3_step(stmt.stmt.int())
+func (stmt *Stmt) Step(colType []sqliteh.ColumnType) (row bool, err error) {
+	var ptr *C.char
+	if len(colType) > 0 {
+		ptr = (*C.char)(unsafe.Pointer(&colType[0]))
+	}
+	res := C.ts_sqlite3_step(stmt.stmt.int(), ptr, C.int(len(colType)))
 	switch res {
 	case C.SQLITE_ROW:
 		return true, nil

--- a/cgosqlite/cgosqlite.h
+++ b/cgosqlite/cgosqlite.h
@@ -110,8 +110,16 @@ static void ts_sqlite3_wal_hook_go(sqlite3* db) {
 	sqlite3_wal_hook(db, wal_callback_into_go, 0);
 }
 
-static int ts_sqlite3_step(handle_sqlite3_stmt stmt) {
-	return sqlite3_step((sqlite3_stmt*)(stmt));
+static int ts_sqlite3_step(handle_sqlite3_stmt stmth, char* outType , int outTypeLen) {
+	sqlite3_stmt* stmt = (sqlite3_stmt*)(stmth);
+	int res = sqlite3_step(stmt);
+	if (res == SQLITE_ROW && outTypeLen > 0) {
+		int cols = sqlite3_column_count(stmt);
+		for (int i = 0; i < cols && i < outTypeLen; i++) {
+			outType[i] = (char) sqlite3_column_type(stmt, i);
+		}
+	}
+	return res;
 }
 
 static const unsigned char *ts_sqlite3_column_text(handle_sqlite3_stmt stmt, int iCol) {

--- a/sqliteh/sqliteh.go
+++ b/sqliteh/sqliteh.go
@@ -87,11 +87,19 @@ type Stmt interface {
 	// https://www.sqlite.org/c3ref/clear_bindings.html
 	ClearBindings() error
 	// Step is sqlite3_step.
-	// 	For SQLITE_ROW, Step returns (true, nil).
-	// 	For SQLITE_DONE, Step returns (false, nil).
-	// 	For any error, Step returns (false, err).
+	//
+	// For SQLITE_ROW, Step returns (true, nil).
+	// For SQLITE_DONE, Step returns (false, nil).
+	// For any error, Step returns (false, err).
+	//
+	// As an optional optimization, if colType is provided, up to len(colType)
+	// bytes are populated with the corresponding ColumnType values. If nil or
+	// zero length, or the result is other than (true, nil), it's not used.
+	// If the slice is too short (len is less than the number of columns), then
+	// the results are truncated.
+	//
 	// https://www.sqlite.org/c3ref/step.html
-	Step() (row bool, err error)
+	Step(colType []ColumnType) (row bool, err error)
 	// StepResult executes a one-row query and resets the statment:
 	//	sqlite3_step
 	//	sqlite3_last_insert_rowid + sqlite3_changes
@@ -171,7 +179,7 @@ type Stmt interface {
 
 // ColumnType are constants for each of the SQLite datatypes.
 // https://www.sqlite.org/c3ref/c_blob.html
-type ColumnType int
+type ColumnType byte
 
 const (
 	SQLITE_INTEGER ColumnType = 1

--- a/sqlitepool/queryglue.go
+++ b/sqlitepool/queryglue.go
@@ -49,7 +49,7 @@ func QueryRow(db sqliteh.DB, sql string, args ...any) *Row {
 	if err := bindAll(db, stmt, args...); err != nil {
 		return &Row{err: fmt.Errorf("QueryRow: %w", err)}
 	}
-	row, err := stmt.Step()
+	row, err := stmt.Step(nil)
 	if err != nil {
 		msg := db.ErrMsg()
 		stmt.Finalize()
@@ -104,7 +104,7 @@ func (rx *Rx) QueryRow(sql string, args ...any) *Row {
 	if err := bindAll(rx.conn.db, stmt, args...); err != nil {
 		return &Row{err: fmt.Errorf("QueryRow: %w", err)}
 	}
-	row, err := stmt.Step()
+	row, err := stmt.Step(nil)
 	if err != nil {
 		msg := rx.DB().ErrMsg()
 		stmt.ResetAndClear()
@@ -137,7 +137,7 @@ func (rs *Rows) Next() bool {
 	if rs.err != nil {
 		return false
 	}
-	row, err := rs.stmt.Step()
+	row, err := rs.stmt.Step(nil)
 	if err != nil {
 		rs.err = fmt.Errorf("QueryRow.Next: %w: %v", err, rs.stmt.DBHandle().ErrMsg())
 		return false

--- a/sqlitepool/sqlitepool.go
+++ b/sqlitepool/sqlitepool.go
@@ -229,7 +229,7 @@ func ExecScript(db sqliteh.DB, queries string) error {
 			return fmt.Errorf("ExecScript: %w: %v, in remaining script: %s", err, db.ErrMsg(), queries)
 		}
 		queries = rem
-		_, err = stmt.Step()
+		_, err = stmt.Step(nil)
 		if err != nil {
 			err = fmt.Errorf("ExecScript: %w: %s: %v", err, stmt.SQL(), db.ErrMsg())
 		}

--- a/sqlitepool/sqlitepool_test.go
+++ b/sqlitepool/sqlitepool_test.go
@@ -122,7 +122,7 @@ func TestPool(t *testing.T) {
 	}
 
 	stmt = rx1.Prepare("SELECT count(*) FROM t")
-	if row, err := stmt.Step(); err != nil {
+	if row, err := stmt.Step(nil); err != nil {
 		t.Fatal(err)
 	} else if !row {
 		t.Fatal("no row from select count")


### PR DESCRIPTION
This recovers the performance loss from the prior commit's bug
fix (#66). Compared to before that, we're now even slightly faster at:

```
                             │   before    │               after2               │
                             │   sec/op    │   sec/op     vs base               │
    WALHookAndExec-8           2.316µ ± 2%   2.297µ ± 1%       ~ (p=0.109 n=10)
    Persist-8                  1.980µ ± 1%   1.956µ ± 0%  -1.26% (p=0.000 n=10)
    QueryRows100MixedTypes-8   36.44µ ± 2%   36.47µ ± 1%       ~ (p=0.289 n=10)
    EmptyExec-8                357.0n ± 2%   355.1n ± 1%       ~ (p=0.697 n=10)
    BeginTxNoop-8              9.178µ ± 0%   9.178µ ± 2%       ~ (p=0.684 n=10)
    geomean                    3.529µ        3.512µ       -0.50%

                             │    before    │                after2                 │
                             │     B/op     │     B/op      vs base                 │
    WALHookAndExec-8             48.00 ± 0%     48.00 ± 0%       ~ (p=1.000 n=10) ¹
    Persist-8                    456.0 ± 0%     440.0 ± 0%  -3.51% (p=0.000 n=10)
    QueryRows100MixedTypes-8   2.719Ki ± 0%   2.703Ki ± 0%  -0.57% (p=0.000 n=10)
    EmptyExec-8                  32.00 ± 0%     32.00 ± 0%       ~ (p=1.000 n=10) ¹
    BeginTxNoop-8                624.0 ± 0%     624.0 ± 0%       ~ (p=1.000 n=10)
    geomean                      261.2          259.1       -0.83%
    ¹ all samples are equal

                             │   before   │               after2                │
                             │ allocs/op  │ allocs/op   vs base                 │
    WALHookAndExec-8           2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=10) ¹
    Persist-8                  11.00 ± 0%   11.00 ± 0%       ~ (p=1.000 n=10) ¹
    QueryRows100MixedTypes-8   107.0 ± 0%   107.0 ± 0%       ~ (p=1.000 n=10) ¹
    EmptyExec-8                1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=10) ¹
    BeginTxNoop-8              13.00 ± 0%   13.00 ± 0%       ~ (p=1.000 n=10) ¹
    geomean                    7.891        7.891       +0.00%
    ¹ all samples are equal
```