### PR TITLE
sqlite: implement driver.SessionResetter and driver.Validator

### DIFF
--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -20,6 +20,13 @@ import (
 	"github.com/tailscale/sqlite/sqliteh"
 )
 
+// SessionResetter and Validator are required in order for conns to be returned
+// to database/sql connection pools.
+var (
+	_ driver.SessionResetter = (*conn)(nil)
+	_ driver.Validator       = (*conn)(nil)
+)
+
 func TestOpenDB(t *testing.T) {
 	db := openTestDB(t)
 	var journalMode string


### PR DESCRIPTION
These implementations enable us to maintain connections in database/sql pools.

Fixes #70