### PR TITLE
cgosqlite: move WAL callback to its own file

### DIFF
--- a/cgosqlite/cgosqlite.go
+++ b/cgosqlite/cgosqlite.go
@@ -61,24 +61,6 @@ import (
 	"github.com/tailscale/sqlite/sqliteh"
 )
 
-type walHookCb func(dbName string, pages int)
-
-var walHookFunc sync.Map // from *C.sqlite3 to walHookCb
-
-//export walCallbackGo
-func walCallbackGo(db *C.sqlite3, dbNameC *C.char, dbNameLen C.int, pages C.int) C.int {
-	v, _ := walHookFunc.Load(db)
-	hook, _ := v.(walHookCb)
-	if hook == nil {
-		return C.int(0)
-	}
-
-	dbNameB := unsafe.Slice((*byte)(unsafe.Pointer(dbNameC)), dbNameLen)
-	dbName := stringFromBytes(dbNameB)
-	hook(dbName, int(pages))
-	return C.int(0) // result's kinda useless
-}
-
 func init() {
 	C.sqlite3_initialize()
 }

--- a/cgosqlite/cgosqlite.h
+++ b/cgosqlite/cgosqlite.h
@@ -5,10 +5,6 @@
 typedef uintptr_t handle_sqlite3_stmt; // a *sqlite3_stmt
 typedef uintptr_t handle_sqlite3; // a *sqlite3 (DB conn)
 
-// Forward decls because the warnings make debugging painful.
-size_t _GoStringLen(_GoString_ s);
-const char *_GoStringPtr(_GoString_ s);
-
 // Helper methods to deal with int <-> pointer pain.
 
 static int bind_text64(handle_sqlite3_stmt stmt, int col, const char* str, sqlite3_uint64 len) {

--- a/cgosqlite/walcallback.go
+++ b/cgosqlite/walcallback.go
@@ -1,0 +1,26 @@
+package cgosqlite
+
+// #include <sqlite3.h>
+import "C"
+import (
+	"sync"
+	"unsafe"
+)
+
+type walHookCb func(dbName string, pages int)
+
+var walHookFunc sync.Map // from *C.sqlite3 to walHookCb
+
+//export walCallbackGo
+func walCallbackGo(db *C.sqlite3, dbNameC *C.char, dbNameLen C.int, pages C.int) C.int {
+	v, _ := walHookFunc.Load(db)
+	hook, _ := v.(walHookCb)
+	if hook == nil {
+		return C.int(0)
+	}
+
+	dbNameB := unsafe.Slice((*byte)(unsafe.Pointer(dbNameC)), dbNameLen)
+	dbName := stringFromBytes(dbNameB)
+	hook(dbName, int(pages))
+	return C.int(0) // result's kinda useless
+}


### PR DESCRIPTION
As per the last comment of golang/go#48824, `_GoStringLen` and `_GoStringPtr` are declared in the preamble unless `//export` is used. To fix the problem, the exported WAL callback function needs to be moved to a separate file.

This removes compiler errors under certain conditions. The most easy way to reproduce this is by attempting to use `dlv`. For some reason, a normal `go` build still succeeds but a `dlv` build does not.

Fixes #75