### PR TITLE
sqlitepool: remove overly clever panic on bind error

### DIFF
--- a/sqlitepool/queryglue.go
+++ b/sqlitepool/queryglue.go
@@ -259,17 +259,8 @@ func scanAll(stmt sqliteh.Stmt, dest ...any) error {
 func bindAll(db sqliteh.DB, stmt sqliteh.Stmt, args ...any) error {
 	for i, arg := range args {
 		if err := bind(db, stmt, i+1, arg); err != nil {
-			// This is counter-intuitive, but you get much better
-			// error messages from a panic here than returning the
-			// error.
-			//
-			// The problem is you ~always need a stack trace to
-			// figure out which SQL query went wrong. By panicing
-			// here you get it.
-			//
-			// This also makes some sense, as a bind error here is
-			// ~always a program error, not something recoverable.
-			panic(err)
+			stmt.ResetAndClear()
+			return fmt.Errorf("bind: %d, %q: %w", i, arg, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
Turns out the described conditions only hold for binding on standard SQL tables. If you use something like FTS5, you can get SQLITE_MISUSE on bind based on user-provided strings. E.g. if you try to search text for something like "autogroup:shared" it turns out FTS5 parses the ':' on bind and treats the prefix as an SQL table column name and returns a MISUSE error, which you don't want to turn into a panic.

So do the boring thing and return an error.

Updates #cleanup