### PR TITLE
sqlite: add an optional explicit interrupt on context termination

### DIFF
--- a/cgosqlite/cgosqlite.go
+++ b/cgosqlite/cgosqlite.go
@@ -132,6 +132,10 @@ func (db *DB) Close() error {
 	return errCode(res)
 }
 
+func (db *DB) Interrupt() {
+	C.sqlite3_interrupt(db.db)
+}
+
 func (db *DB) ErrMsg() string {
 	return C.GoString(C.sqlite3_errmsg(db.db))
 }

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -420,7 +420,7 @@ func TestWithQueryCancel(t *testing.T) {
 			t.Fatalf("QueryContext: unexpected error: %v", err)
 		}
 		for rows.Next() {
-			t.Fatal("Next result available before timeout")
+			t.Error("Next result available before timeout")
 		}
 		if err := rows.Err(); err == nil {
 			t.Error("Rows did not report an error")

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -398,6 +398,45 @@ func TestWithPersist(t *testing.T) {
 	}
 }
 
+func TestWithQueryCancel(t *testing.T) {
+	// This test query runs forever until interrupted.
+	const testQuery = `WITH RECURSIVE inf(n) AS (
+    SELECT 1
+    UNION ALL
+    SELECT n+1 FROM inf
+) SELECT * FROM inf WHERE n = 0`
+
+	db := openTestDB(t)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+
+		rows, err := db.QueryContext(WithQueryCancel(ctx), testQuery)
+		if err != nil {
+			t.Fatalf("QueryContext: unexpected error: %v", err)
+		}
+		for rows.Next() {
+			t.Fatal("Next result available before timeout")
+		}
+		if err := rows.Err(); err == nil {
+			t.Error("Rows did not report an error")
+		} else if !strings.Contains(err.Error(), "SQLITE_INTERRUPT") {
+			t.Errorf("Rows err=%v, want SQLITE_INTERRUPT", err)
+		}
+	}()
+
+	select {
+	case <-done:
+		// OK
+	case <-time.After(time.Second):
+		t.Fatal("Timeout waiting for query to end")
+	}
+}
+
 func TestErrors(t *testing.T) {
 	db := openTestDB(t)
 	exec(t, db, "CREATE TABLE t (c)")

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -432,7 +432,7 @@ func TestWithQueryCancel(t *testing.T) {
 	select {
 	case <-done:
 		// OK
-	case <-time.After(time.Second):
+	case <-time.After(30*time.Second):
 		t.Fatal("Timeout waiting for query to end")
 	}
 }

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -432,7 +432,7 @@ func TestWithQueryCancel(t *testing.T) {
 	select {
 	case <-done:
 		// OK
-	case <-time.After(30*time.Second):
+	case <-time.After(30 * time.Second):
 		t.Fatal("Timeout waiting for query to end")
 	}
 }

--- a/sqliteh/sqliteh.go
+++ b/sqliteh/sqliteh.go
@@ -25,6 +25,9 @@ type DB interface {
 	// Close is sqlite3_close.
 	// https://sqlite.org/c3ref/close.html
 	Close() error
+	// Interrupt is sqlite3_interrupt.
+	// https://www.sqlite.org/c3ref/interrupt.html
+	Interrupt()
 	// ErrMsg is sqlite3_errmsg.
 	// https://sqlite.org/c3ref/errcode.html
 	ErrMsg() string


### PR DESCRIPTION
By default, a query with a time-consuming step may ignore termination of the
context passed in by the driver. Add an option allowing the caller to stipulate
that such queries should be explicitly interrupted (vi sqlite3_interrupt) when
the context ends. This option is disabled by default.
