### PR TITLE
sqlite: cancel completed queries after cleanup, not before

### DIFF
--- a/sqlite.go
+++ b/sqlite.go
@@ -779,7 +779,7 @@ func (r *rows) Close() error {
 		return ErrClosed
 	}
 	r.closed = true
-	r.cancel()
+	defer r.cancel()
 	if err := r.stmt.resetAndClear(); err != nil {
 		return r.stmt.reserr("Rows.Close(Reset)", err)
 	}


### PR DESCRIPTION
In #85 we added an optional mechanism to forcibly interrupt a query that
exceeds its context's lifespan. Move the cancellation during query close until
after cleanup, so that the cancellation of a successful query does not race
with cleanup for setting the result code. (It is not a data race, the accesses
are properly synchronized, but we don't want the cancellation to win unless the
query is actually still running).
