### PR TITLE
sqlite: fix handling of "early" context cancellations

### DIFF
--- a/sqlite.go
+++ b/sqlite.go
@@ -496,16 +496,10 @@ func (s *stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (drive
 
 		db := s.stmt.DBHandle()
 		go func() {
-			running := pctx.Err() == nil
-			select {
-			case <-pctx.Done():
-				// OK, we fell off the end of the exec
-			case <-ctx.Done():
-				// The input context ended; if we haven't already done a cleanup on
-				// this query, interrupt it.
-				if running {
-					db.Interrupt()
-				}
+			started := pctx.Err() == nil
+			<-pctx.Done()
+			if ctx.Err() != nil && started {
+				db.Interrupt()
 			}
 		}()
 	}
@@ -565,16 +559,10 @@ func (s *stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driv
 		cancel = pcancel
 		db := s.stmt.DBHandle()
 		go func() {
-			running := pctx.Err() == nil
-			select {
-			case <-pctx.Done():
-				// OK, we fell off the end of the row loop
-			case <-ctx.Done():
-				// The input context ended; if we haven't already done a cleanup on
-				// this query, interrupt it.
-				if running {
-					db.Interrupt()
-				}
+			started := pctx.Err() == nil
+			<-pctx.Done()
+			if ctx.Err() != nil && started {
+				db.Interrupt()
 			}
 		}()
 	}

--- a/sqlite.go
+++ b/sqlite.go
@@ -490,18 +490,22 @@ func (s *stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (drive
 	if err := s.bindAll(args); err != nil {
 		return nil, s.reserr("Stmt.Exec(Bind)", err)
 	}
+	done := make(chan struct{})
 	if ctx.Value(queryCancelKey{}) != nil {
 		pctx, pcancel := context.WithCancel(ctx)
 		defer pcancel()
 
 		db := s.stmt.DBHandle()
 		go func() {
+			defer close(done)
 			started := pctx.Err() == nil
 			<-pctx.Done()
 			if ctx.Err() != nil && started {
 				db.Interrupt()
 			}
 		}()
+	} else {
+		close(done)
 	}
 	row, lastInsertRowID, changes, duration, err := s.stmt.StepResult()
 	s.bound = false // StepResult resets the query
@@ -513,6 +517,7 @@ func (s *stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (drive
 		return nil, err
 	}
 	_ = row // TODO: return error if exec on query which returns rows?
+	<-done
 	return getStmtResult(lastInsertRowID, changes), nil
 }
 
@@ -554,19 +559,23 @@ func (s *stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driv
 		return nil, err
 	}
 	cancel := func() {}
+	done := make(chan struct{})
 	if ctx.Value(queryCancelKey{}) != nil {
 		pctx, pcancel := context.WithCancel(ctx)
 		cancel = pcancel
 		db := s.stmt.DBHandle()
 		go func() {
+			defer close(done)
 			started := pctx.Err() == nil
 			<-pctx.Done()
 			if ctx.Err() != nil && started {
 				db.Interrupt()
 			}
 		}()
+	} else {
+		close(done)
 	}
-	return &rows{stmt: s, cancel: cancel}, nil
+	return &rows{stmt: s, cancel: cancel, done: done}, nil
 }
 
 func (s *stmt) resetAndClear() error {
@@ -744,6 +753,7 @@ type rows struct {
 	stmt   *stmt
 	closed bool
 	cancel context.CancelFunc // call when query ends
+	done   chan struct{}      // closed when cancellation is done
 
 	// colType is the column types for Step to fill on each row. We only use 23
 	// as it packs well with the closed bool byte above (24 bytes total, same as
@@ -791,7 +801,8 @@ func (r *rows) Close() error {
 		return ErrClosed
 	}
 	r.closed = true
-	defer r.cancel()
+	r.cancel()
+	<-r.done
 	if err := r.stmt.resetAndClear(); err != nil {
 		return r.stmt.reserr("Rows.Close(Reset)", err)
 	}


### PR DESCRIPTION
The optional cancellation hook in #85 and #86 has a deficiency:
If the query successfully completes before its context ends, the cleanup
context would unconditionally trigger an interrupt on the database connection.
That interrupt could race with a subsequent query on that connection, and cause
a spurious cancellation.

To fix this, separate the cleanup context from the input context, and only
effect an interrupt if the _input_ context terminates before cleanup occurs.
Only if cleanup is definitively prior to the query finishing will we effect an
explicit interrupt.

Also: Add a test that demonstrates the original problem.
