### PR TITLE
cgosqlite: do not attempt to reset a NULL statement

### DIFF
--- a/cgosqlite/cgosqlite.go
+++ b/cgosqlite/cgosqlite.go
@@ -244,7 +244,13 @@ func (stmt *Stmt) ResetAndClear() (time.Duration, error) {
 		err := errCode(C.reset_and_clear(stmt.stmt.int(), &stmt.start, &stmt.duration))
 		return time.Duration(stmt.duration), err
 	}
-	return 0, errCode(C.reset_and_clear(stmt.stmt.int(), nil, nil))
+	if sp := stmt.stmt.int(); sp != 0 {
+		return 0, errCode(C.reset_and_clear(stmt.stmt.int(), nil, nil))
+	}
+	// The statement was never initialized. This can happen if, for example, the
+	// parser found only comments (so the statement was not empty, but did not
+	// yield any instructions).
+	return 0, nil
 }
 
 func (stmt *Stmt) StartTimer() {

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -1240,3 +1240,18 @@ func TestPrepareReuse(t *testing.T) {
 		assertResult(rows2, i+1)
 	}
 }
+
+func TestRegression(t *testing.T) {
+	// A regression test for a query comprising only comments, which caused the
+	// driver to panic in statement cleanup.
+	t.Run("CommentOnlyQuery", func(t *testing.T) {
+		db := openTestDB(t)
+
+		rows, err := db.Query("-- comments only\n-- nothing else")
+		if err != nil {
+			t.Fatalf("Query failed: %v", err)
+		}
+		rows.Next()
+		t.Log("OK") // Reaching here at all means we didn't panic.
+	})
+}


### PR DESCRIPTION
Presenting a query consisting of only comments results in a statement with a
NULL underlying cStmt. The SQL text is syntactically valid, but when attempting
to clean up after a query on such a statement, the indirection through NULL
triggers a panic.

Check during cleanup for this degenerate case, and don't try to reset the
statement in that case. Add a regression test for the original failure.

Signed-off-by: M. J. Fromberger <fromberger@tailscale.com>
