### PR TITLE
sqlite: revert context-based cancellation hooks from #85

### DIFF
--- a/cgosqlite/cgosqlite.go
+++ b/cgosqlite/cgosqlite.go
@@ -132,10 +132,6 @@ func (db *DB) Close() error {
 	return errCode(res)
 }
 
-func (db *DB) Interrupt() {
-	C.sqlite3_interrupt(db.db)
-}
-
 func (db *DB) ErrMsg() string {
 	return C.GoString(C.sqlite3_errmsg(db.db))
 }

--- a/sqlite.go
+++ b/sqlite.go
@@ -490,14 +490,6 @@ func (s *stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (drive
 	if err := s.bindAll(args); err != nil {
 		return nil, s.reserr("Stmt.Exec(Bind)", err)
 	}
-	if ctx.Value(queryCancelKey{}) != nil {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithCancel(ctx)
-		defer cancel()
-
-		db := s.stmt.DBHandle()
-		go func() { <-ctx.Done(); db.Interrupt() }()
-	}
 	row, lastInsertRowID, changes, duration, err := s.stmt.StepResult()
 	s.bound = false // StepResult resets the query
 	err = s.reserr("Stmt.Exec", err)
@@ -548,13 +540,7 @@ func (s *stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driv
 	if err := s.bindAll(args); err != nil {
 		return nil, err
 	}
-	cancel := func() {}
-	if ctx.Value(queryCancelKey{}) != nil {
-		ctx, cancel = context.WithCancel(ctx)
-		db := s.stmt.DBHandle()
-		go func() { <-ctx.Done(); db.Interrupt() }()
-	}
-	return &rows{stmt: s, cancel: cancel}, nil
+	return &rows{stmt: s}, nil
 }
 
 func (s *stmt) resetAndClear() error {
@@ -731,7 +717,6 @@ func colDeclTypeFromString(s string) colDeclType {
 type rows struct {
 	stmt   *stmt
 	closed bool
-	cancel context.CancelFunc // call when query ends
 
 	// colType is the column types for Step to fill on each row. We only use 23
 	// as it packs well with the closed bool byte above (24 bytes total, same as
@@ -779,7 +764,6 @@ func (r *rows) Close() error {
 		return ErrClosed
 	}
 	r.closed = true
-	defer r.cancel()
 	if err := r.stmt.resetAndClear(); err != nil {
 		return r.stmt.reserr("Rows.Close(Reset)", err)
 	}
@@ -1015,13 +999,3 @@ func WithPersist(ctx context.Context) context.Context {
 
 // persistQuery is used as a context value.
 type persistQuery struct{}
-
-// WithQueryCancel makes a ctx that instructs the sqlite driver to explicitly
-// interrupt a running query if its argument context ends.  By default, without
-// this option, queries will only check the context between steps.
-func WithQueryCancel(ctx context.Context) context.Context {
-	return context.WithValue(ctx, queryCancelKey{}, queryCancelKey{})
-}
-
-// queryCancelKey is a context key for query context enforcement.
-type queryCancelKey struct{}

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -398,45 +398,6 @@ func TestWithPersist(t *testing.T) {
 	}
 }
 
-func TestWithQueryCancel(t *testing.T) {
-	// This test query runs forever until interrupted.
-	const testQuery = `WITH RECURSIVE inf(n) AS (
-    SELECT 1
-    UNION ALL
-    SELECT n+1 FROM inf
-) SELECT * FROM inf WHERE n = 0`
-
-	db := openTestDB(t)
-
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-
-		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
-		defer cancel()
-
-		rows, err := db.QueryContext(WithQueryCancel(ctx), testQuery)
-		if err != nil {
-			t.Fatalf("QueryContext: unexpected error: %v", err)
-		}
-		for rows.Next() {
-			t.Error("Next result available before timeout")
-		}
-		if err := rows.Err(); err == nil {
-			t.Error("Rows did not report an error")
-		} else if !strings.Contains(err.Error(), "SQLITE_INTERRUPT") {
-			t.Errorf("Rows err=%v, want SQLITE_INTERRUPT", err)
-		}
-	}()
-
-	select {
-	case <-done:
-		// OK
-	case <-time.After(30 * time.Second):
-		t.Fatal("Timeout waiting for query to end")
-	}
-}
-
 func TestErrors(t *testing.T) {
 	db := openTestDB(t)
 	exec(t, db, "CREATE TABLE t (c)")

--- a/sqliteh/sqliteh.go
+++ b/sqliteh/sqliteh.go
@@ -25,9 +25,6 @@ type DB interface {
 	// Close is sqlite3_close.
 	// https://sqlite.org/c3ref/close.html
 	Close() error
-	// Interrupt is sqlite3_interrupt.
-	// https://www.sqlite.org/c3ref/interrupt.html
-	Interrupt()
 	// ErrMsg is sqlite3_errmsg.
 	// https://sqlite.org/c3ref/errcode.html
 	ErrMsg() string


### PR DESCRIPTION
The interaction between cleanup and reuse of the connection makes this feature
hard to use as-written. While #87 proposes a couple ways to fix the issue,
let's revert the partial state of things; we can fold these changes in with the
fix once we have consensus.

- Revert "sqlite: cancel completed queries after cleanup, not before (#86)"
  This reverts commit 78a5f32445416db077d122abf09e8aa78202246e.

- Revert "sqlite: add an optional explicit interrupt on context termination (#85)"
  This reverts commit 607d0c19ac5c651c2a4f9f9836552ef9be08221d.
