### PR TITLE
sqlstats: export Collect for metrics in tests

### DIFF
--- a/sqlstats/sqlstats_test.go
+++ b/sqlstats/sqlstats_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 
@@ -69,6 +70,52 @@ func TestNormalizeQuery(t *testing.T) {
 	for _, tt := range tests {
 		if got := normalizeQuery(tt.q); got != tt.want {
 			t.Errorf("normalizeQuery(%#q) = %#q; want %#q", tt.q, got, tt.want)
+		}
+	}
+}
+
+func TestCollect(t *testing.T) {
+	tracer := &Tracer{}
+	db := sql.OpenDB(sqlite.Connector("file:"+t.TempDir()+"/test.db", nil, tracer))
+	defer db.Close()
+
+	ctx := context.Background()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx, "CREATE TABLE t (c);"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.ExecContext(ctx, "INSERT INTO t (c) VALUES (1);"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.ExecContext(ctx, "INSERT INTO t (c) VALUES (1);"); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	gotStats := tracer.Collect()
+	slices.SortFunc(gotStats, func(a, b *QueryStats) int {
+		if a.Query < b.Query {
+			return -1
+		}
+		return 1
+	})
+
+	// List containing expecting query counts in order.
+	wantCount := []int{1, 1, 1, 2}
+
+	if len(gotStats) != len(wantCount) {
+		t.Errorf("unexpected number of queries compared to defined count, queries: %d, want: %d", len(gotStats), len(wantCount))
+	}
+
+	for idx, query := range gotStats {
+		if query.Count != int64(wantCount[idx]) {
+			t.Errorf("unexpected query count for %q, got: %d, expected: %d", query.Query, query.Count, wantCount[idx])
 		}
 	}
 }


### PR DESCRIPTION
This PR exports the QueryStats and Collect method so it can be used to gather statistics and used during tests.

Used in https://github.com/tailscale/corp/pull/16678