### PR TITLE
sqlstats: fix Tracer.Reset data races

### DIFF
--- a/sqlstats/sqlstats.go
+++ b/sqlstats/sqlstats.go
@@ -43,15 +43,28 @@ type Tracer struct {
 
 // Reset resets the state of t to its initial conditions.
 func (t *Tracer) Reset() {
+	if t.TxCount != nil {
+		t.TxCount.Init()
+	}
+	if t.TxCommit != nil {
+		t.TxCommit.Init()
+	}
+	if t.TxCommitError != nil {
+		t.TxCommitError.Init()
+	}
+	if t.TxRollback != nil {
+		t.TxRollback.Init()
+	}
+	if t.TxTotalSeconds != nil {
+		t.TxTotalSeconds.Init()
+	}
+	t.curTxs.Range(func(key, value any) bool {
+		t.curTxs.Delete(key)
+		return true
+	})
+
 	t.mu.Lock()
 	defer t.mu.Unlock()
-
-	t.TxCount = nil
-	t.TxCommit = nil
-	t.TxCommitError = nil
-	t.TxRollback = nil
-	t.TxTotalSeconds = nil
-	t.curTxs = sync.Map{}
 	t.queries = nil
 }
 


### PR DESCRIPTION
I failed to test the previous Reset implementation with `-race`, thinking that because it was only used in a Test, a straightforward zeroing of all of the fields would suffice. This proved not to be the case, and so I'm fixing it now:

```
$ go test ./sqlstats/ -run Race -race -count 20
ok  	github.com/tailscale/sqlite/sqlstats	21.289s
```