### PR TITLE
cgosqlite: include time.h for clock_gettime

### DIFF
--- a/cgosqlite/cgosqlite.h
+++ b/cgosqlite/cgosqlite.h
@@ -1,4 +1,5 @@
 #include "stdint.h"
+#include "time.h"
 
 // uintptr versions of sqlite3 pointer types, to avoid allocations
 // in cgo code. (go/corp/9919)


### PR DESCRIPTION
This has been missing for some time, but my compiler driver got stricter and started failing on this.