### PR TITLE
Fix macOS build regression from XOPEN_SOURCE=600

### DIFF
--- a/.github/workflows/test-sqlite.yml
+++ b/.github/workflows/test-sqlite.yml
@@ -8,7 +8,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
 

--- a/cgosqlite/cgosqlite.go
+++ b/cgosqlite/cgosqlite.go
@@ -32,6 +32,7 @@ package cgosqlite
 //
 // // Select POSIX 2014 at least for clock_gettime.
 // #cgo CFLAGS: -D_XOPEN_SOURCE=600
+// #cgo CFLAGS: -D_DARWIN_C_SOURCE=1
 // #cgo linux CFLAGS: -std=c99
 //
 // // On Android, unlike Linux, there are no separate libpthread or librt


### PR DESCRIPTION
This fixes the regression, also adds a macOS CI pipeline.