### PR TITLE
cgosqlite: add more string interns, and optimize

### DIFF
--- a/cgosqlite/stubs.go
+++ b/cgosqlite/stubs.go
@@ -1,0 +1,10 @@
+package cgosqlite
+
+import _ "unsafe"
+
+// findnull exposes the runtime.findnull function to the cgosqlite package, this
+// is a wide instruction optimized page by page null byte search aka fast
+// strlen.
+//
+//go:linkname findnull runtime.findnull
+func findnull(*byte) int

--- a/cgosqlite/walcallback.go
+++ b/cgosqlite/walcallback.go
@@ -20,7 +20,7 @@ func walCallbackGo(db *C.sqlite3, dbNameC *C.char, dbNameLen C.int, pages C.int)
 	}
 
 	dbNameB := unsafe.Slice((*byte)(unsafe.Pointer(dbNameC)), dbNameLen)
-	dbName := stringFromBytes(dbNameB)
+	dbName := internStringFromBytes(dbNameB)
 	hook(dbName, int(pages))
 	return C.int(0) // result's kinda useless
 }


### PR DESCRIPTION
This adds string interning to column names, table names and database names, as well as optimizing the decltype interning code path to use runtime.findnull rather than C.strlen that must cross cgo again.

We don't yet know if this is effective in practice, and should test this before integrating.