### PR TITLE
cgosqlite: set SQLITE_TEMP_STORE=1

### DIFF
--- a/cgosqlite/cgosqlite.go
+++ b/cgosqlite/cgosqlite.go
@@ -28,6 +28,7 @@ package cgosqlite
 // #cgo CFLAGS: -DSQLITE_ENABLE_COLUMN_METADATA
 // #cgo CFLAGS: -DSQLITE_ENABLE_STAT4
 // #cgo CFLAGS: -DSQLITE_ENABLE_DBSTAT_VTAB=1
+// #cgo CFLAGS: -DSQLITE_TEMP_STORE=1
 // #cgo CFLAGS: -DHAVE_USLEEP=1
 //
 // // Select POSIX 2014 at least for clock_gettime.


### PR DESCRIPTION
SQLITE_TEMP_STORE=1 allows PRAGMA temp_store = MEMORY, while keeping temporary files as the default behavior for temporary storage.

This can be used to accelerate some migrations, when building an in-memory temporary btree to use in a later correlated subquery is faster than the query planner would normally do things, for example when optimizing locality or btree operation order.