### PR TITLE
sqlite: fix handling of "early" context cancellations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/tailscale/sqlite
 
-go 1.20
+go 1.21

--- a/sqlite.go
+++ b/sqlite.go
@@ -494,7 +494,7 @@ func (s *stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (drive
 	if ctx.Value(queryCancelKey{}) != nil {
 		done = make(chan struct{})
 		pctx, pcancel := context.WithCancel(ctx)
-		defer pcancel()
+		defer pcancel() // to make the AfterFunc fire and close(done)
 
 		db := s.stmt.DBHandle()
 		stop := context.AfterFunc(pctx, func() {

--- a/sqlite.go
+++ b/sqlite.go
@@ -756,7 +756,7 @@ type rows struct {
 	stmt   *stmt
 	closed bool
 	cancel context.CancelFunc // call when query ends
-	done   chan struct{}      // closed when cancellation is done
+	done   chan struct{}      // either nil, or closed when cancellation is done
 
 	// colType is the column types for Step to fill on each row. We only use 23
 	// as it packs well with the closed bool byte above (24 bytes total, same as

--- a/sqlite.go
+++ b/sqlite.go
@@ -503,8 +503,9 @@ func (s *stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (drive
 				db.Interrupt()
 			}
 		})
-		// In the event we get an error from the initial step and exit early,
-		// dissociate the cancellation since we don't need it.
+		// In the event we get an error from the query's initial execution of
+		// sqlite3_step below and exit early, dissociate the cancellation since
+		// we don't want it to fire and potentially stop a later execution.
 		defer stop()
 	}
 

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"reflect"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -418,7 +419,8 @@ func TestWithQueryCancel(t *testing.T) {
 
 		rows, err := db.QueryContext(WithQueryCancel(ctx), testQuery)
 		if err != nil {
-			t.Fatalf("QueryContext: unexpected error: %v", err)
+			t.Errorf("QueryContext: unexpected error: %v", err)
+			return
 		}
 		for rows.Next() {
 			t.Error("Next result available before timeout")
@@ -435,6 +437,37 @@ func TestWithQueryCancel(t *testing.T) {
 		// OK
 	case <-time.After(30 * time.Second):
 		t.Fatal("Timeout waiting for query to end")
+	}
+}
+
+func TestWithQueryCancel_OK(t *testing.T) {
+	db := openTestDB(t)
+
+	for i := 0; i < 100; i++ {
+		t.Run(strconv.Itoa(i+1), func(t *testing.T) {
+			// Set a timeout that is much longer than the expected runtime of the query.
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			rows, err := db.QueryContext(WithQueryCancel(ctx), `select 1`)
+			if err != nil {
+				t.Fatalf("QueryContext: unexpected error: %v", err)
+			}
+			for rows.Next() {
+				var z int
+				if err := rows.Scan(&z); err != nil {
+					t.Fatalf("Scan: %v", err)
+				} else if z != 1 {
+					t.Errorf("Scan: got %d, want 1", z)
+				}
+			}
+			if err := rows.Err(); err != nil {
+				t.Errorf("Err reported %v", err)
+			}
+			if err := rows.Close(); err != nil {
+				t.Errorf("Close reported %v", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
(A restatement of #87)

The optional cancellation hook in #85 and #86 has a deficiency: If the query successfully completes before its context ends, the cleanup context would unconditionally trigger an interrupt on the database connection. That interrupt could race with a subsequent query on that connection, and cause a spurious cancellation.

To fix this, separate the cleanup context from the input context, and only effect an interrupt if the _input_ context terminates before cleanup occurs. Only if cleanup is definitively prior to the query finishing will we effect an explicit interrupt.

Also: Add a test that demonstrates the original problem.