### PR TITLE
sqlite: fix cancellation cleanup for ExecContext

### DIFF
--- a/sqlite.go
+++ b/sqlite.go
@@ -501,6 +501,9 @@ func (s *stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (drive
 		db := s.stmt.DBHandle()
 		context.AfterFunc(pctx, func() {
 			defer close(done)
+
+			// Note: We respond to cancellation on the primary context (ctx) not
+			// the cleanup context (pctx).
 			if ctx.Err() != nil {
 				db.Interrupt()
 			}
@@ -570,6 +573,9 @@ func (s *stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driv
 		db := s.stmt.DBHandle()
 		context.AfterFunc(pctx, func() {
 			defer close(done)
+
+			// Note: We respond to cancellation on the primary context (ctx) not
+			// the cleanup context (pctx).
 			if ctx.Err() != nil {
 				db.Interrupt()
 			}


### PR DESCRIPTION
I did not test the changes in #103 sufficiently, and missed a corner case in
ExecContext: We need to make sure the context cleanup happens prior to the
synchronization, not in a defer.

Add a test to actually trigger this case, and fix the cleanup so it happens
before return as intended.
