### PR TITLE
cgosqlite: silence warnings about unknown warnings

### DIFF
--- a/cgosqlite/cgosqlite.go
+++ b/cgosqlite/cgosqlite.go
@@ -38,6 +38,10 @@ package cgosqlite
 // // Quiet bogus warnings (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115274)
 // #cgo CFLAGS: -Wno-stringop-overread
 //
+// // Ignore unknown warning options, to silence spurious complaints from
+// // Apple's build of Clang that does not know certain GCC warnings.
+// #cgo CFLAGS: -Wno-unknown-warning-option
+//
 // // libm is required by the FTS5 extension, on Linux.
 // #cgo linux LDFLAGS: -lm
 //


### PR DESCRIPTION
Some Clang builds, notably the one shipped on ARM by Apple, do not understand
all the same warning flags that GCC does. Suppress spurious warnings for these
to avert build noise.

Updates tailscale/corp#21834
