### PR TITLE
cgosqlite: quiet bogus gcc warning

### DIFF
--- a/cgosqlite/cgosqlite.go
+++ b/cgosqlite/cgosqlite.go
@@ -39,6 +39,9 @@ package cgosqlite
 // // Apple's build of Clang that does not know certain GCC warnings.
 // #cgo CFLAGS: -Wno-unknown-warning-option
 //
+// // Quiet bogus warnings (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115274)
+// #cgo CFLAGS: -Wno-stringop-overread
+//
 // // libm is required by the FTS5 extension, on Linux.
 // #cgo linux LDFLAGS: -lm
 //


### PR DESCRIPTION
(This is a cherry-pick of 23ab76b to reapply the change which got reverted in 0263f7d.)

This is a relatively recent issue, so should likely be fixed upstream in either sqlite or gcc. But in the meantime, quiet this warning.

Updates #cleanup