### PR TITLE
conditionally compile released SQLite on ifndef SQLITE_TRUNK

### DIFF
--- a/cgosqlite/cgosqlite.go
+++ b/cgosqlite/cgosqlite.go
@@ -8,7 +8,6 @@ package cgosqlite
 // One exception is we do not use SQLITE_OMIT_DECLTYPE, as the design
 // of the database/sql driver seems to require it.
 
-#cgo !sqlite_trunk CFLAGS: -DSQLITE_RELEASE
 #cgo sqlite_trunk CFLAGS: -DSQLITE_TRUNK
 #cgo CFLAGS: -DSQLITE_THREADSAFE=2
 #cgo CFLAGS: -DSQLITE_DQS=0

--- a/cgosqlite/sqlite3.c
+++ b/cgosqlite/sqlite3.c
@@ -1,4 +1,4 @@
-#ifdef SQLITE_RELEASE
+#ifndef SQLITE_TRUNK
 
 /******************************************************************************
 ** This file is an amalgamation of many separate C source files from SQLite

--- a/cgosqlite/sqlite3_trunk.c
+++ b/cgosqlite/sqlite3_trunk.c
@@ -69164,6 +69164,7 @@ static int walCheckpoint(
       ** the wal file. It would also be dangerous to proceed, as there may be
       ** fewer than pWal->hdr.mxFrame valid frames in the wal file.  */
       int bChg = memcmp(pLive->aSalt, pWal->hdr.aSalt, sizeof(pWal->hdr.aSalt));
+      if( bChg ) sqlite3_log(SQLITE_WARNING, "wal wrapped after header was read for this checkpoint");
       if( 0==bChg ){
         pInfo->nBackfillAttempted = mxSafeFrame; SEH_INJECT_FAULT;
 

--- a/update-sqlite.sh
+++ b/update-sqlite.sh
@@ -42,7 +42,7 @@ unzip "$filename" || fatal "Unzip of $filename failed"
 mv "$dirname"/*.{c,h} .
 mv shell.c shell.c.disabled
 mv sqlite3.c sqlite3.c_partial
-printf "#ifdef SQLITE_RELEASE\n\n" > sqlite3.c
+printf "#ifndef SQLITE_TRUNK\n\n" > sqlite3.c
 cat sqlite3.c_partial >> sqlite3.c
 printf "\n\n#endif\n" >> sqlite3.c
 rm sqlite3.c_partial


### PR DESCRIPTION
Also log a warning when SQLite trunk detects when the WAL is wrapped after the header was read for a checkpoint.

Updates tailscale/corp#37997